### PR TITLE
250530 프로젝트 개발 진행 내용(to dev4 Merge)

### DIFF
--- a/Koflearn/IKoflearnPlatManager.cpp
+++ b/Koflearn/IKoflearnPlatManager.cpp
@@ -1,0 +1,6 @@
+#include "IKoflearnPlatManager.h"
+
+// 순수 가상 소멸자 정의(필수)
+IKoflearnPlatManager::~IKoflearnPlatManager() {
+	cout << "~IKoflearnPlatManager ()\n";
+}

--- a/Koflearn/IKoflearnPlatManager.h
+++ b/Koflearn/IKoflearnPlatManager.h
@@ -1,0 +1,34 @@
+#ifndef IKOFLEARN_PLAT_MANAGER_H
+#define IKOFLEARN_PLAT_MANAGER_H
+
+#include <iostream>
+using namespace std;
+
+// 순환 참조 방지로 각 매니저 클래스들을 [전방 선언]
+/* 전방 선언 사용 CASE
+ 헤더 파일에서 다른 클래스의 전체 정의가 필요 없고 
+ 단순히 포인터나 참조 타입으로만 사용할 경우, #include 대신 전방 선언을 사용
+*/
+class MemberManager;
+class LectureManager;
+class LoginManager;
+class EnrollManager;
+class MyPageManager;
+class SessionManager;
+
+// KoflearnPlatManager 의 인터페이스 정의
+class IKoflearnPlatManager {
+public:
+	virtual ~IKoflearnPlatManager() = 0;
+
+	// 모든 매니저(컨트롤러) 에 대한 가상 getter 순수 함수를 포함
+	virtual MemberManager& getMemberManager() = 0;
+	virtual LectureManager& getLectureManager() = 0;
+	virtual LoginManager& getLoginManager() = 0;
+	virtual EnrollManager& getEnrollManager() = 0;
+	virtual MyPageManager& getMyPageManager() = 0;
+	// SessionManager 헤더파일 & 클래스 추가
+	virtual SessionManager& getSessionManager() = 0;
+};
+
+#endif

--- a/Koflearn/Koflearn_main.cpp
+++ b/Koflearn/Koflearn_main.cpp
@@ -4,8 +4,11 @@ using namespace std;
 
 int main()
 {
-    KoflearnPlatManager* program = KoflearnPlatManager::getInstance();
-    program->displayMenu();
+    // koflearnPlatManager 구현체
+    KoflearnPlatManager mainProgram;
 
+    // displayMenu는 주입받은 program_context를 통해 
+    // 이미 mainProgram 내부에 존재하는 매니저 객체들에 접근 가능함
+    mainProgram.displayMenu(&mainProgram);
     return 0;
 }

--- a/Koflearn/enrollManager.cpp
+++ b/Koflearn/enrollManager.cpp
@@ -189,6 +189,9 @@ void EnrollManager::searchAndStudentEnrollLecture() {
 
             // 학생 키로 map 에서 vector 찾기
             auto it = this->studentLectureList.find(studentKey);
+            // 추가하려는 강의의 "수강자 수" 를 증가 시킴
+            int temp = lecture->getEnrolledStudentsCount();
+            lecture->setEnrolledStudentsCount(++temp);
 
             if (it != this->studentLectureList.end()) {
                 // 학생이 이미 존재할 때 해당 학생 강의 리스트에 새 강의 추가
@@ -253,6 +256,23 @@ void EnrollManager::instructorEnrollLecture() {
 
     }
     return;
+}
+
+string EnrollManager::makeWelcomeText() {
+    string welcomeText = "님 안녕하세요. 지금 새 강의를 수강신청해보세요 !";
+    unsigned long long myPrimaryKey = program_interface->getSessionManager().getLoginUser()->getPrimaryKey();
+    map<unsigned long long, vector<Lecture*>>& studentLectureList = program_interface->getEnrollManager().getStudentLectureList();
+    bool is_own = false;
+
+    for (const auto& i : studentLectureList) {
+        if (i.first == myPrimaryKey) {
+            is_own = true;
+        }
+    }
+    if (is_own) {
+        welcomeText = "님 안녕하세요. 현재 수강중인 강의가 있어요 !";
+    }
+    return welcomeText;
 }
 
 // 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,

--- a/Koflearn/enrollManager.cpp
+++ b/Koflearn/enrollManager.cpp
@@ -111,7 +111,7 @@ EnrollManager::~EnrollManager() {
             // map<unsigned long long, vector<Lecture*>> 에서 vector<Lecture*> 를 먼저 얻고
             // for 문 순환 필요함
             for (Lecture* lecture : v.second) {
-                file1 << member->getPrimaryKey() << ", "
+                file2 << member->getPrimaryKey() << ", "
                     << member->getNickName() << ", "
                     << member->getEmail() << ", "
                     << member->getPassword() << ", "

--- a/Koflearn/enrollManager.h
+++ b/Koflearn/enrollManager.h
@@ -6,6 +6,7 @@
 #include "IKoflearnPlatManager.h"
 #include <iostream>
 #include <map>
+#include <vector>
 using namespace std;
 
 class EnrollManager {
@@ -14,8 +15,15 @@ private:
 	IKoflearnPlatManager* program_interface;
 
 private:
-	map<Member*, Lecture*> studentLectureList;
-	map<Member*, Lecture*> instructorLectureList;
+	/*
+		std 컨테이너의 key가 포인터 타입인 경우, 
+		맵은 포인터가 가리키는 객체의 내용이 아니라 포인터 주소 값으로 검색하여
+		의도하지 않은 반환 값이나 에러 발생 위험 있음
+		-> 키를 클래스 객체 포인터 로 쓰는 모든 맵(2개) 들을 <unsigned long long, Lecture*> 로 변경
+			(앞쪽 unsigned long long 에는 member 의 primarykey 가 들어감)
+	*/
+	map<unsigned long long, vector<Lecture*>> studentLectureList;
+	map<unsigned long long, vector<Lecture*>> instructorLectureList;
 
 public:
 	// 생성자에서 인터페이스 타입 의존성을 주입받음
@@ -28,8 +36,18 @@ public:
 	
 	vector<string> parseCSV(istream&, char);
 
-	map<Member*, Lecture*> getStudentLectureList();
-	map<Member*, Lecture*> getInstructorLectureList();
+	// 1.
+	// 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,
+	// "임시 객체" 가 생성되고 반환 직후 ; 을 만나 문장이 끝나면 임시 컨테이너 객체가 소멸됨.
+	// => "댕글링 포인터" 이슈 발생!!
+	// * 해결 : 컨테이너 객체를 변수에 할당하여 반환할 때, "복사하지 않고" "참조" 값을 반환한다.
+	// 2. stl 컨테이너 사용 에러 : map<unsigned long long, Lecture*> 형태일 경우
+	/*
+		한 학생은 하나의 강의 밖에 수강하지 못함 : 한 key 는 고유하기 때문에 중복해서 
+		같은 key 를 삽입할 수 없음. 이후 key 를 삽입하려 할 때는 key, value 삽입 자체가 무시됨.
+	*/
+	map<unsigned long long, vector<Lecture*>>& getStudentLectureList();
+	map<unsigned long long, vector<Lecture*>>& getInstructorLectureList();
 };
 
 #endif // ! _ENROLLMANAGER_H_

--- a/Koflearn/enrollManager.h
+++ b/Koflearn/enrollManager.h
@@ -34,7 +34,11 @@ public:
 	void instructorEnrollLecture();
 	bool isDuplicationStudentEnrollLecture(Member* member, Lecture* lecture);
 	
+	string makeWelcomeText();
+
 	vector<string> parseCSV(istream&, char);
+
+
 
 	// 1.
 	// 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,

--- a/Koflearn/enrollManager.h
+++ b/Koflearn/enrollManager.h
@@ -3,26 +3,23 @@
 
 #include "member.h"
 #include "lecture.h"
+#include "IKoflearnPlatManager.h"
 #include <iostream>
 #include <map>
 using namespace std;
 
-// KoflearnPlatManager 전방 선언
-class KoflearnPlatManager;
-
 class EnrollManager {
+private:
+	// Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+	IKoflearnPlatManager* program_interface;
+
 private:
 	map<Member*, Lecture*> studentLectureList;
 	map<Member*, Lecture*> instructorLectureList;
 
-	// 250529 commit 로그에 작성하지 못한 내용(friend - daily 과제에 추가할 것.)
-	// myPageManager 에서는 EnrollManager 의 private 인 "강의듣는 리스트", "강의하는 리스트"
-	// 를 받아와야 하기 때문에 myPageManager 와의 [friend] 선언
-	friend class MyPageManager;
-	friend class LectureManager;
-
 public:
-	EnrollManager();
+	// 생성자에서 인터페이스 타입 의존성을 주입받음
+	EnrollManager(IKoflearnPlatManager* program);
 	~EnrollManager();
 
 	void searchAndStudentEnrollLecture();
@@ -33,8 +30,6 @@ public:
 
 	map<Member*, Lecture*> getStudentLectureList();
 	map<Member*, Lecture*> getInstructorLectureList();
-
-	KoflearnPlatManager* getInstance() const;
 };
 
 #endif // ! _ENROLLMANAGER_H_

--- a/Koflearn/koflearnPlatManager.cpp
+++ b/Koflearn/koflearnPlatManager.cpp
@@ -1,16 +1,15 @@
 #include "koflearnPlatManager.h"
 #include <sstream>
 
-// 소스 코드 파일(cpp)에서 singleton 인스턴스 초기화
-KoflearnPlatManager* KoflearnPlatManager::instance = nullptr;
-
-KoflearnPlatManager* KoflearnPlatManager::getInstance() {
-    if (!instance) {
-        instance = new KoflearnPlatManager();
-    }
-    return instance;
-}
-
+KoflearnPlatManager::KoflearnPlatManager()
+    : // 초기화 리스트에서 'this' 포인터를 사용하여 각 매니저의 생성자에 의존성 주입
+    memberManager(this),
+    lectureManager(this),
+    loginManager(this),
+    enrollManager(this),
+    myPageManager(this),
+    sessionManager(this)
+{};
 
 MemberManager& KoflearnPlatManager::getMemberManager() {
     return this->memberManager;
@@ -32,31 +31,11 @@ EnrollManager& KoflearnPlatManager::getEnrollManager() {
     return this->enrollManager;
 }
 
-Member* KoflearnPlatManager::getLoginUser() {
-    return this->loginUser;
+SessionManager& KoflearnPlatManager::getSessionManager() {
+    return this->sessionManager;
 }
 
-void KoflearnPlatManager::setLoginUser(Member* member) {
-    this->loginUser = member;
-}
-
-bool KoflearnPlatManager::getIs_login() {
-    return this->is_login;
-}
-
-void KoflearnPlatManager::setIs_login(bool boolean) {
-    this->is_login = boolean;
-}
-
-bool KoflearnPlatManager::getIs_admin() {
-    return this->is_admin;
-}
-
-void KoflearnPlatManager::setIs_admin(bool boolean) {
-    this->is_admin = boolean;
-}
-
-void KoflearnPlatManager::displayMenu() {
+void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
     int ch;
     bool isContinue = true;
 
@@ -65,8 +44,8 @@ void KoflearnPlatManager::displayMenu() {
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << "          Koflearn Main page                 " << endl;
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
-        if (this->getIs_login() == true) {
-            cout << this->loginUser->getNickName() + " 님 안녕하세요. 현재 수강중인 강의가 있어요 !" << endl << endl;
+        if (program->getSessionManager().getIs_login() == true) {
+            cout << program->getSessionManager().getLoginUser()->getNickName() + " 님 안녕하세요. 현재 수강중인 강의가 있어요 !" << endl << endl;
             cout << "  0. 마이페이지                            " << endl;
             cout << "  1. 로그아웃                              " << endl;
         }
@@ -85,68 +64,74 @@ void KoflearnPlatManager::displayMenu() {
 
         switch (ch) {
         case 0:
-            if (this->getIs_login() == true) {
+            if (program->getSessionManager().getIs_login() == true) {
                 this->myPageManager.displayMenu();
             }
             break;
         case 1:
-            if (this->getIs_login() == true) {
+            if (program->getSessionManager().getIs_login() == true) {
                 // 로그아웃
-                this->setIs_login(false);
-                this->loginUser = nullptr;
-                this->setIs_admin(false);
+                program->getSessionManager().setIs_login(false);
+                program->getSessionManager().setLoginUser(nullptr);
+                program->getSessionManager().setIs_admin(false);
 
                 cout << "정상적으로 로그아웃 되었습니다. " << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             else {
                 // 로그인 화면 이동
-                this->loginManager.displayMenu();
+                program->getLoginManager().displayMenu();
             }
             break;
         case 2:
-            if (this->getIs_login() == true) {
-                this->lectureManager.displayAllLecture();
-                this->enrollManager.searchAndStudentEnrollLecture();
+            if (program->getSessionManager().getIs_login() == true) {
+                program->getLectureManager().displayAllLecture();
+                program->getEnrollManager().searchAndStudentEnrollLecture();
             }
             else {
                 cout << "로그인 후 강의 조회 및 신청이 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             break;
         case 3:
-            if (this->getIs_login() == true) {
-                this->lectureManager.inputLecture();
+            if (program->getSessionManager().getIs_login() == true) {
+                program->getLectureManager().inputLecture();
                 cout << "강의를 신규 등록하였습니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             else {
                 cout << "로그인 후 강의 등록이 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             break;
         case 4:
-            if (this->getIs_login() == true && this->getIs_admin() == true) {
-                this->memberManager.displayMenu();
+            if (program->getSessionManager().getIs_login() == true && program->getSessionManager().getIs_admin() == true) {
+                program->getMemberManager().displayMenu();
             }
             else {
                 cout << "멤버(회원) 통합 관리 시스템은 관리자만 접근 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             break;
         case 5:
-            if (this->getIs_login() == true && this->getIs_admin() == true) {
-                this->lectureManager.displayMenu();
+            if (program->getSessionManager().getIs_login() == true && program->getSessionManager().getIs_admin() == true) {
+                program->getLectureManager().displayMenu();
             }
             else {
                 cout << "강의(제품) 통합 관리 시스템은 관리자만 접근 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             break;
         case 6:
@@ -156,8 +141,4 @@ void KoflearnPlatManager::displayMenu() {
             break;
         }
     }
-
-    // ! 싱글톤 인스턴스를 동적으로 할당했다면, 프로그램 종료 전에 반드시 delete !
-    // getInstance() 내부에서 new KoflearnPlatManager()를 사용했으므로, 여기서 delete !!!
-    delete this;
 }

--- a/Koflearn/koflearnPlatManager.cpp
+++ b/Koflearn/koflearnPlatManager.cpp
@@ -45,7 +45,8 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
         cout << "          Koflearn Main page                 " << endl;
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         if (program->getSessionManager().getIs_login() == true) {
-            cout << program->getSessionManager().getLoginUser()->getNickName() + " 님 안녕하세요. 현재 수강중인 강의가 있어요 !" << endl << endl;
+            string welcomeText = program->getEnrollManager().makeWelcomeText();
+            cout << program->getSessionManager().getLoginUser()->getNickName() + welcomeText << endl << endl;
             cout << "  0. 마이페이지                            " << endl;
             cout << "  1. 로그아웃                              " << endl;
         }

--- a/Koflearn/koflearnPlatManager.cpp
+++ b/Koflearn/koflearnPlatManager.cpp
@@ -60,7 +60,21 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        cin.ignore();
+
+        // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
+        // 무한 깜빡임 현상 해결
+        if (cin.fail()) {
+            cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+            // 스트림의 오류 상태를 초기화
+            cin.clear();
+            cout << "[Enter] 를 눌러 뒤로가기" << endl;
+            while (getchar() != '\n');
+            // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
+        }
+        // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
         switch (ch) {
         case 0:

--- a/Koflearn/koflearnPlatManager.h
+++ b/Koflearn/koflearnPlatManager.h
@@ -5,44 +5,39 @@
 #include "loginManager.h"
 #include "myPageManager.h"
 #include "enrollManager.h"
-
+#include "sessionManager.h"
+#include "IKoflearnPlatManager.h"
 #include <iostream>
 
-class KoflearnPlatManager {
+// 인터페이스를 상속받은 구현체
+class KoflearnPlatManager : public IKoflearnPlatManager {
 private:
-	static KoflearnPlatManager* instance;
-	bool is_login = false;
-	bool is_admin = false;
-	Member* loginUser = nullptr;
-	KoflearnPlatManager(){};
-
-	// manager 컨트롤러 클래스들 초기화(1회)
+	// 실제 manager 객체들 선언
+	// KoflearnPlatManager 메인 컨트롤러 Manager 클래스의 객체가 만들어 질 때
+	// 이미 실제 manager 객체들이 KoflearnPlatManager() 생성자의 초기화 리스트에서 
+	// 'this' 포인터를 사용하여 각 매니저의 생성자에 주입 !!
+	// 해당 객체들은 KoflearnPlatManager 메인 컨트롤러와 수명 주기를 함께한다.
 	MemberManager memberManager;
 	LectureManager lectureManager;
 	LoginManager loginManager;
 	EnrollManager enrollManager;
 	MyPageManager myPageManager;
+	SessionManager sessionManager;
 
 public:
-	static KoflearnPlatManager* getInstance();
+	KoflearnPlatManager();
 
-	// 전체 프로그램에서 로그인 유무에 따라 동작을 달리하기 위함(로그인 세션 관리)
-	Member* getLoginUser();
-	void setLoginUser(Member* member);
-	bool getIs_login();
-	void setIs_login(bool isTrue);
-	bool getIs_admin();
-	void setIs_admin(bool isTrue);
+	// 메인 컨트롤러 Manager 클래스에 있는 특정 멤버 변수에 대한 reference value 반환을 위함
+	MemberManager& getMemberManager() override;
+	LectureManager& getLectureManager() override;
+	LoginManager& getLoginManager() override;
+	MyPageManager& getMyPageManager() override;
+	EnrollManager& getEnrollManager() override;
+	SessionManager& getSessionManager() override;
 
-	// 한 manager 클래스에서 다른 manager 클래스에 접근하도록 생성한 
-	// manager 들에 대해 get 함수를 선언함
-	MemberManager& getMemberManager();
-	LectureManager& getLectureManager();
-	LoginManager& getLoginManager();
-	MyPageManager& getMyPageManager();
-	EnrollManager& getEnrollManager();
-
-	void displayMenu();
+	// main 에서 KoflearnPlatManager 를 한 번 생성하므로 displayMenu() 멤버 함수는 
+	// 종합 컨트롤러 Manager(인터페이스 구현체) 에서 선언 !
+	void displayMenu(IKoflearnPlatManager* program);
 };
 
 #endif // !_KOFLEARN_MANAGER_

--- a/Koflearn/lectureManager.cpp
+++ b/Koflearn/lectureManager.cpp
@@ -297,7 +297,21 @@ void LectureManager::displayMenu()
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        while (getchar() != '\n');
+        
+        // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
+        // 무한 깜빡임 현상 해결
+        if (cin.fail()) {
+            cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+            // 스트림의 오류 상태를 초기화
+            cin.clear();
+            cout << "[Enter] 를 눌러 뒤로가기" << endl;
+            while (getchar() != '\n');
+            // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
+        }
+        // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
 
         switch (ch) {

--- a/Koflearn/lectureManager.h
+++ b/Koflearn/lectureManager.h
@@ -1,24 +1,22 @@
 #ifndef _LECTURE_MANAGER_H_
 #define _LECTURE_MANAGER_H_
 
+#include "lecture.h"
+#include "IKoflearnPlatManager.h"
 #include <vector>
 #include <map>
-#include "lecture.h"
 #include <iostream>
 using namespace std;
 
-// KoflearnPlatManager 전방 선언
-class KoflearnPlatManager;
-
 class LectureManager {
-public:
-	LectureManager();
-	~LectureManager();
+private:
+	// Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+	IKoflearnPlatManager* program_interface;
 
-	// EnrollManager::searchAndStudentEnrollLecture() 에서 lectureList 직접 사용
-	friend class EnrollManager;
-	// MyPageManager::allDeletedUserData: 회원 삭제 시 연관된 데이터를 지우기 위한 friend
-	friend class MyPageManager;
+public:
+	// 생성자에서 인터페이스 타입 의존성을 주입받음
+	LectureManager(IKoflearnPlatManager* program);
+	~LectureManager();
 
 	Lecture* inputLecture();
 	void addLecture(Lecture* lecture);
@@ -32,8 +30,6 @@ public:
 	void displayMenu();
 
 	map<unsigned long long, Lecture*> getLectureList();
-
-	KoflearnPlatManager* getInstance() const;
 
 private:
 	map<unsigned long long, Lecture*> lectureList;

--- a/Koflearn/lectureManager.h
+++ b/Koflearn/lectureManager.h
@@ -29,7 +29,11 @@ public:
 	vector<string> parseCSV(istream&, char);
 	void displayMenu();
 
-	map<unsigned long long, Lecture*> getLectureList();
+	// 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,
+	// "임시 객체" 가 생성되고 반환 직후 ; 을 만나 문장이 끝나면 임시 컨테이너 객체가 소멸됨.
+	// => "댕글링 포인터" 이슈 발생!!
+	// * 해결 : 컨테이너 객체를 변수에 할당하여 반환할 때, "복사하지 않고" "참조" 값을 반환한다.
+	map<unsigned long long, Lecture*>& getLectureList();
 
 private:
 	map<unsigned long long, Lecture*> lectureList;

--- a/Koflearn/loginManager.cpp
+++ b/Koflearn/loginManager.cpp
@@ -1,14 +1,23 @@
-// koflearnPlatManager.h 에 loginManager.h 포함
-#include "koflearnPlatManager.h"
+#include "loginManager.h"
+// program_interface 를 통해서 접근하려는 모든 
+// Manager 클래스들이 필요한 헤더 파일이 include 되어 있어야 함. 
+// why? 순환참조 방지로 IKoflearnPlatManager 에서 Manager 클래스들을 include 하지 않고
+//      전방선언 처리했으므로
+#include "memberManager.h"
+#include "sessionManager.h"
 
 #include <string>
+using namespace std;
 
-LoginManager::LoginManager() {}
-LoginManager::~LoginManager() {}
-
-KoflearnPlatManager* LoginManager::getInstance() const{
-	return KoflearnPlatManager::getInstance();
+// 생성자에서 인터페이스 타입의 의존성을 주입받음
+LoginManager::LoginManager(IKoflearnPlatManager* program) 
+    : program_interface(program)
+{
+    if (!program_interface) {
+        cerr << "오류: MyPageManager에 유효한 IKoflearnPlatManager가 주입되지 않았습니다!\n";
+    }
 }
+LoginManager::~LoginManager() {}
 
 void LoginManager::displayMenu()
 {
@@ -18,7 +27,6 @@ void LoginManager::displayMenu()
     string email, password;
     Member* loginMember = nullptr;
     Member* member = nullptr;
-    KoflearnPlatManager* program = getInstance();
     Member* joinMember = nullptr;
 
     while (isContinue == true) {
@@ -38,11 +46,12 @@ void LoginManager::displayMenu()
         case 1:
             cout << "ID : ";
             getline(cin, email, '\n');
-            loginMember = program->getMemberManager().searchMember(email);
+            loginMember = program_interface->getMemberManager().searchMember(email);
             if (loginMember == nullptr) {
                 cout << "가입되지 않은 이메일입니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 while (getchar() != '\n');
+
             }
             else {
                 cout << "비밀번호 : ";
@@ -51,39 +60,43 @@ void LoginManager::displayMenu()
                     cout << "패스워드를 다시 확인해주세요." << endl;
                     cout << "[Enter] 를 눌러 뒤로가기" << endl;
                     while (getchar() != '\n');
+
                 }
                 else {
                     cout << loginMember->getNickName() + " 님 환영합니다." << endl;
-                    program->setIs_login(true);
-                    program->setLoginUser(loginMember);
+                    program_interface->getSessionManager().setIs_login(true);
+                    program_interface->getSessionManager().setLoginUser(loginMember);
 
                     if (loginMember->getIsManager() == "true") {
-                        program->setIs_admin(true);
+                        program_interface->getSessionManager().setIs_admin(true);
                     }
                     cout << "[Enter] 를 눌러 메인 페이지로 이동" << endl;
                     while (getchar() != '\n');
+
                     isContinue = false;
                 }
             }
             break;
         case 2: 
-            joinMember = program->getMemberManager().inputMember();
+            joinMember = program_interface->getMemberManager().inputMember();
             if (joinMember != nullptr)  {
                 cout << "회원 가입이 완료되었습니다." << endl;
-                program->setIs_login(true);
-                program->setLoginUser(joinMember);
-                member = program->getLoginUser();
+                program_interface->getSessionManager().setIs_login(true);
+                program_interface->getSessionManager().setLoginUser(joinMember);
+                member = program_interface->getSessionManager().getLoginUser();
                 if (member->getIsManager() == "true") {
-                    program->setIs_admin(true);
+                    program_interface->getSessionManager().setIs_admin(true);
                 }
                 cout << "[Enter] 를 눌러 메인 페이지로 자동 로그인됩니다." << endl;
                 while (getchar() != '\n');
+
                 isContinue = false;
             }
             else {
                 cout << "회원 가입이 취소되었습니다." << endl;
                 cout << "[Enter] 를 눌러 메인 페이지로 돌아가기" << endl;
                 while (getchar() != '\n');
+
                 isContinue = false;
             }
             break;

--- a/Koflearn/loginManager.cpp
+++ b/Koflearn/loginManager.cpp
@@ -40,7 +40,21 @@ void LoginManager::displayMenu()
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        cin.ignore();
+
+        // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
+         // 무한 깜빡임 현상 해결
+        if (cin.fail()) {
+            cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+            // 스트림의 오류 상태를 초기화
+            cin.clear();
+            cout << "[Enter] 를 눌러 뒤로가기" << endl;
+            while (getchar() != '\n');
+            // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
+        }
+        // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
         switch (ch) {
         case 1:

--- a/Koflearn/loginManager.h
+++ b/Koflearn/loginManager.h
@@ -1,34 +1,21 @@
 #ifndef _LOGIN_MANAGER_H_
 #define _LOGIN_MANAGER_H_
 
-
-// koflearnPlatManager.h 주석 사유
-// loginManager 에서 싱글톤 객체를 가져오는 getInstance 를 사용함으로써 loginManager.h 에도 koflearnPlatManager.h 를 include 할 경우
-// 계속 circular include 하는 "순환 참조" 현상이 발생한다. 
-// koflearnPlatManager 에서는 싱글톤 객체 주소만 받아오면 되므로 
-// koflearnPlatManager.h 를 include 대신 koflearnPlatManager 클래스 자체를 "전방 선언" 으로 작성한다.
-//#include "koflearnPlatManager.h"
+#include "IKoflearnPlatManager.h"
 #include <iostream>
 using namespace std;
 
-// KoflearnPlatManager 전방 선언
-class KoflearnPlatManager;
-
 class LoginManager {
+private:
+	// Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+	IKoflearnPlatManager* program_interface;
+
 public:
-	LoginManager();              
+	// 생성자에서 인터페이스 타입 의존성을 주입받음
+	LoginManager(IKoflearnPlatManager* program);
 	~LoginManager();
 
-	// Koflearn 싱글톤 객체에 있는 membermanager 서비스(member 정보 추적)를 사용하기 위해
-	// 싱글톤 객체 인스턴스를 가져옴
-	// 싱글톤 객체를 가져오는 getInstance 를 사용함으로써 loginManager.h 에도 koflearnPlatManager.h 를 include 할 경우
-	// 계속 circular include 하는 "순환 참조" 현상이 발생한다. 따라서 loginManager 자체 멤버 변수를 사용할 일은 없으므로
-	// loginManager.h 에서 koflearnPlatManager.h 를 include 하는 대신 koflearnPlatManager 클래스 자체를 "전방 선언" 으로 작성한다.
-	KoflearnPlatManager* getInstance() const;
 	void displayMenu();
-
 };
-
-
 
 #endif // !_LOGIN_MANAGER_H_

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -350,7 +350,11 @@ vector<string> MemberManager::parseCSV(istream& file, char delimiter)
     return row;
 }
 
-map<unsigned long long, Member*> MemberManager::getMemberList() {
+// 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,
+// "임시 객체" 가 생성되고 반환 직후 ; 을 만나 문장이 끝나면 임시 컨테이너 객체가 소멸됨.
+// => "댕글링 포인터" 이슈 발생!!
+// * 해결 : 컨테이너 객체를 변수에 할당하여 반환할 때, "복사하지 않고" "참조" 값을 반환한다.
+map<unsigned long long, Member*>& MemberManager::getMemberList() {
     return this->memberList;
 }
 

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -1,20 +1,20 @@
+#include "member.h"
+#include "memberManager.h"
+
 #include <vector>
 #include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <iomanip>
-#include <sstream>
-
-#include "member.h"
-#include "koflearnPlatManager.h"
-// koflearnPlatManager 에 mamberManager 포함
-// #include "memberManager.h"
-#include "koflearnPlatform.h"
-
 using namespace std;
 
-MemberManager::MemberManager()
+// 생성자에서 인터페이스 타입의 의존성을 주입받음
+MemberManager::MemberManager(IKoflearnPlatManager* program)
+    : program_interface(program)
 { 
+    if (!program_interface) {
+        cerr << "오류: MyPageManager에 유효한 IKoflearnPlatManager가 주입되지 않았습니다!\n";
+    }
     ifstream file;
     file.open("memberList.txt");
     char* endptr;
@@ -49,10 +49,6 @@ MemberManager::~MemberManager()
         }
     }
     file.close();
-}
-
-KoflearnPlatManager* MemberManager::getInstance() const {
-    return KoflearnPlatManager::getInstance();
 }
 
 Member* MemberManager::inputMember()
@@ -233,6 +229,7 @@ void MemberManager::displayAllMembers() const {
         cout << "등록된 멤버가 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
         return;
     }
 
@@ -378,37 +375,44 @@ void MemberManager::displayMenu()
         cin >> ch;
         while (getchar() != '\n');
 
+
         switch (ch) {
         case 1: default:
             displayAllMembers();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             while (getchar() != '\n');
+
             break;
         case 2:
             inputMember();
             cout << "회원가입이 완료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             while (getchar() != '\n');
+
             break;
         case 3:
             displayAllMembers();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
             while (getchar() != '\n');
+
             deleteMember(key);
             cout << "멤버 삭제 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             while (getchar() != '\n');
+
             break;
         case 4:
             displayAllMembers();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
             while (getchar() != '\n');
+
             modifyMember(key);
             cout << "멤버 수정 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             while (getchar() != '\n');
+
             break;
         case 5:
             isContinue = false;

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -377,7 +377,21 @@ void MemberManager::displayMenu()
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        while (getchar() != '\n');
+        
+        // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
+        // 무한 깜빡임 현상 해결
+        if (cin.fail()) {
+            cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+            // 스트림의 오류 상태를 초기화
+            cin.clear();
+            cout << "[Enter] 를 눌러 뒤로가기" << endl;
+            while (getchar() != '\n');
+            // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
+        }
+        // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
 
         switch (ch) {

--- a/Koflearn/memberManager.h
+++ b/Koflearn/memberManager.h
@@ -36,7 +36,11 @@ public:
     vector<string> parseCSV(istream&, char);
     void displayMenu();
 
-    map<unsigned long long, Member*> getMemberList();
+    // 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,
+    // "임시 객체" 가 생성되고 반환 직후 ; 을 만나 문장이 끝나면 임시 컨테이너 객체가 소멸됨.
+    // => "댕글링 포인터" 이슈 발생!!
+    // * 해결 : 컨테이너 객체를 변수에 할당하여 반환할 때, "복사하지 않고" "참조" 값을 반환한다.
+    map<unsigned long long, Member*>& getMemberList();
 
 private:
     map<unsigned long long, Member*> memberList;

--- a/Koflearn/memberManager.h
+++ b/Koflearn/memberManager.h
@@ -1,18 +1,22 @@
 #ifndef _MEMBER_MANAGER_H_
 #define _MEMBER_MANAGER_H_
 
+#include "member.h"
+#include "IKoflearnPlatManager.h"
 #include <vector>
 #include <map>
-#include "member.h"
 #include <iostream>
 using namespace std;
 
-// KoflearnPlatManager 전방 선언
-class KoflearnPlatManager;
 
 class MemberManager {
+private:
+    // Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+    IKoflearnPlatManager* program_interface;
+
 public:
-    MemberManager();               // 생성자 선언
+    // 생성자에서 인터페이스 타입 의존성을 주입받음
+    MemberManager(IKoflearnPlatManager* program);               // 생성자 선언
     ~MemberManager();              // 소멸자 선언
 
     Member* inputMember();
@@ -33,8 +37,6 @@ public:
     void displayMenu();
 
     map<unsigned long long, Member*> getMemberList();
-
-    KoflearnPlatManager* getInstance() const;
 
 private:
     map<unsigned long long, Member*> memberList;

--- a/Koflearn/myPageManager.cpp
+++ b/Koflearn/myPageManager.cpp
@@ -1,21 +1,31 @@
-// koflearnPlatManager.h 에 myPageManager.h 가 포함되어 있음
-#include "koflearnPlatManager.h"
-
+#include "myPageManager.h"
 #include <string>
+// program_interface 를 통해서 접근하려는 모든 
+// Manager 클래스들이 필요한 헤더 파일이 include 되어 있어야 함. 
+// why? 순환참조 방지로 IKoflearnPlatManager 에서 Manager 클래스들을 include 하지 않고
+//      전방선언 처리했으므로
+#include "enrollManager.h"
+#include "sessionManager.h"
+#include "memberManager.h"
+#include "lectureManager.h"
 
-MyPageManager::MyPageManager() {}
-MyPageManager::~MyPageManager() {}
 
-KoflearnPlatManager* MyPageManager::getInstance() const {
-	return KoflearnPlatManager::getInstance();
+// 생성자에서 인터페이스 타입 의존성을 주입받음
+MyPageManager::MyPageManager(IKoflearnPlatManager* program)
+    : program_interface(program)
+{
+    if (!program_interface) {
+        cerr << "오류: MyPageManager에 유효한 IKoflearnPlatManager가 주입되지 않았습니다!\n";
+    }
 }
+MyPageManager::~MyPageManager() {}
 
 void MyPageManager::myStudentLecturePrint() {
     int cnt = 0;
     cout << "    key      |            Title          |   teacher   |    price    |   students   |   hours   |   level  |" << endl;
-    for (const auto& i : getInstance()->getEnrollManager().studentLectureList) {
+    for (const auto& i : program_interface->getEnrollManager().getStudentLectureList()) {
         Lecture* lecture = nullptr;
-        if (i.first->getNickName() == getInstance()->getLoginUser()->getNickName()) {
+        if (i.first->getNickName() == program_interface->getSessionManager().getLoginUser()->getNickName()) {
             lecture = i.second;
             lecture->displayInfo();
             cnt++;
@@ -26,20 +36,22 @@ void MyPageManager::myStudentLecturePrint() {
         cout << "현재 수강 중인 강좌가 없습니다 !" << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
     }
     else {
         cout << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
     }
 }
 
 void MyPageManager::myInstructorLecturePrint() {
     int cnt = 0;
     cout << "    key      |            Title          |   teacher   |    price    |   students   |   hours   |   level  |" << endl;
-    for (const auto& i : getInstance()->getEnrollManager().instructorLectureList) {
+    for (const auto& i : program_interface->getEnrollManager().getInstructorLectureList()) {
         Lecture* lecture = nullptr;
-        if (i.first->getNickName() == getInstance()->getLoginUser()->getNickName()) {
+        if (i.first->getNickName() == program_interface->getSessionManager().getLoginUser()->getNickName()) {
             lecture = i.second;
             lecture->displayInfo();
             cnt++;
@@ -50,16 +62,17 @@ void MyPageManager::myInstructorLecturePrint() {
         cout << "현재 진행하시는 강좌가 없습니다 !" << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
     }
     else {
         cout << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
     }
 }
 
 bool MyPageManager::selfDeleteID() {
-    KoflearnPlatManager* program = getInstance();
     string is_delete = "";
 
     cout << "탈퇴 시 수강하시는 강의, 강의하시는 강좌 모두 제거됩니다." << endl;
@@ -71,31 +84,33 @@ bool MyPageManager::selfDeleteID() {
         // 탈퇴자 관련 데이터 우선 제거(lectureList, instructorLectureList, studentLectureList)
         allDeletedUserData();
         // 탈퇴자 member 데이터 제거
-        program->getMemberManager().deleteMember(program->getLoginUser()->getPrimaryKey());
+        Member* member = program_interface->getSessionManager().getLoginUser();
+        program_interface->getMemberManager().deleteMember(member->getPrimaryKey());
         
         cout << "회원 탈퇴가 정상적으로 되었습니다." << endl;
         cout << "로그인 상태가 해제되고 [Enter] 를 누르면 메인 페이지로 이동합니다." << endl;
         while (getchar() != '\n');
+
         return true;
     }
     else {
         cout << "문구를 정상적으로 입력하지 않아 회원 탈퇴를 진행할 수 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         while (getchar() != '\n');
+
         return false;
     }
 }
 
 void MyPageManager::allDeletedUserData() {
-    KoflearnPlatManager* program = getInstance();
-    string instructorName = program->getLoginUser()->getNickName();
+    string instructorName = program_interface->getSessionManager().getLoginUser()->getNickName();
 
     // lectureList data 제거
-    auto i = program->getLectureManager().lectureList.begin();
-    while (i != program->getLectureManager().lectureList.end()) {
+    auto i = program_interface->getLectureManager().getLectureList().begin();
+    while (i != program_interface->getLectureManager().getLectureList().end()) {
         if (i->second->getInstructorName().compare(instructorName) == 0) {
             // i(iterator) 를 삭제된 다음 위치로 update
-            i = program->getLectureManager().lectureList.erase(i);
+            i = program_interface->getLectureManager().getLectureList().erase(i);
         }
         else {
             // 조건을 만족하지 않으면 다음 요소로 이동
@@ -104,11 +119,11 @@ void MyPageManager::allDeletedUserData() {
     }
 
     // instructorLectureList data 제거
-    auto i2 = program->getEnrollManager().instructorLectureList.begin();
-    while (i2 != program->getEnrollManager().instructorLectureList.end()) {
+    auto i2 = program_interface->getEnrollManager().getInstructorLectureList().begin();
+    while (i2 != program_interface->getEnrollManager().getInstructorLectureList().end()) {
         if (i2->first->getNickName().compare(instructorName) == 0) {
             // i(iterator) 를 삭제된 다음 위치로 update
-            i2 = program->getEnrollManager().instructorLectureList.erase(i2);
+            i2 = program_interface->getEnrollManager().getInstructorLectureList().erase(i2);
         }
         else {
             // 조건을 만족하지 않으면 다음 요소로 이동
@@ -117,12 +132,12 @@ void MyPageManager::allDeletedUserData() {
     }
 
     // studentLectureList data 제거
-    auto i3 = program->getEnrollManager().studentLectureList.begin();
+    auto i3 = program_interface->getEnrollManager().getStudentLectureList().begin();
 
-    while (i3 != program->getEnrollManager().studentLectureList.end()) {
+    while (i3 != program_interface->getEnrollManager().getStudentLectureList().end()) {
         if (i3->first->getNickName().compare(instructorName) == 0) {
             // i(iterator) 를 삭제된 다음 위치로 update
-            i3 = program->getEnrollManager().studentLectureList.erase(i3);
+            i3 = program_interface->getEnrollManager().getStudentLectureList().erase(i3);
         }
         else {
             // 조건을 만족하지 않으면 다음 요소로 이동
@@ -139,7 +154,7 @@ void MyPageManager::displayMenu() {
     bool is_delete = false;
 
     string email, password;
-    KoflearnPlatManager* program = getInstance();
+    Member* member = program_interface->getSessionManager().getLoginUser();
 
     while (isContinue == true) {
         cout << "\033[2J\033[1;1H";
@@ -164,14 +179,14 @@ void MyPageManager::displayMenu() {
             this->myInstructorLecturePrint();
             break;
         case 3:
-            program->getMemberManager().modifyMember(program->getLoginUser()->getPrimaryKey());
+            program_interface->getMemberManager().modifyMember(member->getPrimaryKey());
             break;
         case 4:
             is_delete = this->selfDeleteID();
             if (is_delete == true) {
-                program->setIs_login(false);
-                program->setIs_admin(false);
-                program->setLoginUser(nullptr);
+                program_interface->getSessionManager().setIs_login(false);
+                program_interface->getSessionManager().setIs_admin(false);
+                program_interface->getSessionManager().setLoginUser(nullptr);
 
                 isContinue = false;
             }

--- a/Koflearn/myPageManager.cpp
+++ b/Koflearn/myPageManager.cpp
@@ -196,7 +196,21 @@ void MyPageManager::displayMenu() {
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        cin.ignore();
+        
+        // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
+        // 무한 깜빡임 현상 해결
+        if (cin.fail()) {
+            cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+            // 스트림의 오류 상태를 초기화
+            cin.clear();
+            cout << "[Enter] 를 눌러 뒤로가기" << endl;
+            while (getchar() != '\n');
+            // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
+        }
+        // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
         switch (ch) {
         case 1:

--- a/Koflearn/myPageManager.h
+++ b/Koflearn/myPageManager.h
@@ -1,18 +1,19 @@
 #ifndef _MYPAGE_MANAGER_H_
 #define _MYPAGE_MANAGER_H_
-
+#include "IKoflearnPlatManager.h"
 #include <iostream>
 using namespace std;
 
-// KoflearnPlatManager 전방 선언
-class KoflearnPlatManager;
-
 class MyPageManager {
+private:
+	// Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+	IKoflearnPlatManager* program_interface;
+
 public:
-	MyPageManager();
+	// 생성자에서 인터페이스 타입 의존성을 주입받음
+	MyPageManager(IKoflearnPlatManager* program);
 	~MyPageManager();
 	        
-	KoflearnPlatManager* getInstance() const;
 	void displayMenu();
 	void myStudentLecturePrint();
 	void myInstructorLecturePrint();

--- a/Koflearn/sessionManager.cpp
+++ b/Koflearn/sessionManager.cpp
@@ -1,0 +1,36 @@
+#include "member.h"
+#include "sessionManager.h"
+
+// 생성자에서 인터페이스 타입의 의존성을 주입받음
+SessionManager::SessionManager(IKoflearnPlatManager* program)
+    : program_interface(program)
+{
+    if (!program_interface) {
+        cerr << "오류: MyPageManager에 유효한 IKoflearnPlatManager가 주입되지 않았습니다!\n";
+    }
+}
+SessionManager::~SessionManager() {}
+
+Member* SessionManager::getLoginUser() {
+    return this->loginUser;
+}
+
+void SessionManager::setLoginUser(Member* member) {
+    this->loginUser = member;
+}
+
+bool SessionManager::getIs_login() {
+    return this->is_login;
+}
+
+void SessionManager::setIs_login(bool boolean) {
+    this->is_login = boolean;
+}
+
+bool SessionManager::getIs_admin() {
+    return this->is_admin;
+}
+
+void SessionManager::setIs_admin(bool boolean) {
+    this->is_admin = boolean;
+}

--- a/Koflearn/sessionManager.h
+++ b/Koflearn/sessionManager.h
@@ -1,0 +1,37 @@
+#ifndef SESSION_MANAGER_H
+#define SESSION_MANAGER_H
+
+#include "IKoflearnPlatManager.h"
+// program_interface 를 통해서 접근하려는 모든 
+// Manager 클래스들이 필요한 헤더 파일이 include 되어 있어야 함. 
+// why? 순환참조 방지로 IKoflearnPlatManager 에서 Manager 클래스들을 include 하지 않고
+//      전방선언 처리했으므로
+#include "member.h"
+#include <iostream>
+using namespace std;
+
+class SessionManager {
+private:
+    // Manager 가 인터페이스에 의존하도록 인터페이스 포인터 선언
+    IKoflearnPlatManager* program_interface;
+
+public:
+    // 생성자에서 인터페이스 타입 의존성을 주입받음
+    SessionManager(IKoflearnPlatManager* program);
+    ~SessionManager();
+
+    // 전체 프로그램에서 로그인 유무에 따라 동작을 달리하기 위함(로그인 세션 관리)
+    Member* getLoginUser();
+    void setLoginUser(Member* member);
+    bool getIs_login();
+    void setIs_login(bool isTrue);
+    bool getIs_admin();
+    void setIs_admin(bool isTrue);
+
+private:
+    bool is_login = false;
+    bool is_admin = false;
+    Member* loginUser = nullptr;
+};
+
+#endif


### PR DESCRIPTION
**Feat**
1. commit log - 2df5173 : 로그인 회원이 수강하는 강의가 있을 때, 없을 때 메인 메시지 문구 출력
-> 로그인 회원이 수강하는 강의가 있을 때 : "님 안녕하세요. 현재 수강중인 강의가 있어요 !" 메시지를 메인화면에 출력
로그인 회원이 수강하는 강의가 없을 때 : "님 안녕하세요. 지금 새 강의를
수강신청해보세요 !" 메시지를 메인화면에 출력

**Fix & Refactor**
1. commit log - 9c6879e : 기존 싱글턴 코드에서 의존성 주입 코드로 전체 코드 변경
-> 프로젝트 진행 사항에 "책임 중심 설계" 가 기반되어야 한다는 전제가 있었음.. 이에 따라 기존 싱글턴 패턴의 코드를 모두 의존성 주입 방식의 "책임 중심 설계" 에 부합하는 코드로 전체 변경
- 세부 구현 내용 :
1-1. 각 컨트롤러 Manager 들을 통합 관리하는 통합 컨트롤러 Manager(koflearnPlatManager) 의 인터페이스를 정의하고, 이 인터페이스를 상속받음.
1-2. 인터페이스 구현체인 KoflearnPlatManager 는 초기화 시 내부 컨트롤러 Manager 들에 인터페이스를 매개변수로 넣어 내부 컨트롤러 Manager들에 의존성을 주입
1-3. 각 내부 컨트롤러 Manager 의 소스 코드 중 기존 싱글턴 패턴 -> 의존성 주입이 적용되도록 코드 수정

**Feat & Fix**
1. commit log - 9989180 : 중복 강의 수강 신청 방지 기능 추가
-> 한 학생이 중복되지 않은 여러 강의를 수강하려고 할 때 map<unsigned long long, Lecture*> 형태의 컨테이너일 경우, 한 학생은 무조건 하나의 강의 밖에 수강하지 못하게됨.
   why? Map 에서 한 key 는 하나의 value 만 담을 수 있기 때문에 이후 같은
   key 에 value 를 담으려는 시도했더니 삽입이 무시되었음.
   -> 기존 한 학생이 수강하는 여러 강좌 리스트, 한 강의자가 강의하는 여러 강좌 리스트를 map<unsigned long long, Lecture*> 형태에서 map<unsigned long long, vector<Lecture*>> 형태로 다시 선언 하였으며, 이에 따라 unsigned long long 타입의 key 로 value 를 삽입할 때 2가지 케이스에 따라 다르게 동작하도록 함
   	CASE 1. 이미 Key 가 존재할 때 vector 에 담으려면 :
	   iterator->second.push_back(item);
	CASE 2. key 가 존재하지 않아서 새 vector 를 추가하고 담으려면 :
	   list.insert({key, {item}});
   로 동작을 구현하였음.

**Fix**
1. commit log - 9989180 : 컨테이너 객체 댕글링 이슈 처리
-> STL 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환받아서 받고 할당했을 때, "임시 객체" 로 생성되고 반환 직후 ';' 를 만나 문장이 끝나면 임시 컨테이너 객체가 소멸됨. => "댕글링 포인터" 이슈 발생하여 컨테이너 객체를 변수에 할당하여 반환할 때 , "복사" 하지 않고 "참조"(레퍼런스) 값을 반환하도록 함
2. commit log - 4920796 : enrollManager에서 instructorLectureList.txt 파일 저장 안되는 문제 수정
-> commit 당시 114 line "file1" 이 아닌 "file2" 였어야 함.
3. commit log - 9e5afaa : 메인 포함 모든 Manager 메뉴 UI 에서 지정 숫자 명령이 아닐 때 버그 수정
-> 메뉴에서 지정한 숫자 명령어가 아닌 다른 영문자 등을 입력했을 때 무한
깜빡임 버그 발생하여 cin.fail() 조건문으로 잘못된 입력을 알리고 오류 상태 초기화 및 버퍼를
정상적으로 비우도록 함
