### PR TITLE
5월 31일 ~ 6월 1일 기능 추가 및 수정 사항

### DIFF
--- a/Koflearn/enrollManager.cpp
+++ b/Koflearn/enrollManager.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 
 // 생성자에서 인터페이스 타입의 의존성을 주입받음
-EnrollManager::EnrollManager(IKoflearnPlatManager* program) 
+EnrollManager::EnrollManager(IKoflearnPlatManager* program)
     : program_interface(program)
 {
     if (!program_interface) {
@@ -44,8 +44,8 @@ EnrollManager::EnrollManager(IKoflearnPlatManager* program)
                 // map<unsigned long long, vector<Lecture*>>
                 // map<unsigned long long, Lecture*> 형태일 경우
                 /*
-                한 학생은 하나의 강의 밖에 수강하지 못함 : 한 key 는 고유하기 때문에 중복해서 
-	            같은 key 를 삽입할 수 없음. 
+                한 학생은 하나의 강의 밖에 수강하지 못함 : 한 key 는 고유하기 때문에 중복해서
+                같은 key 를 삽입할 수 없음.
                 */
                 studentLectureList.insert({ member->getPrimaryKey(), { lecture } });
             }
@@ -105,7 +105,7 @@ EnrollManager::~EnrollManager() {
             }
         }
     }
-    if(!file2.fail()){
+    if (!file2.fail()) {
         for (const auto& v : instructorLectureList) {
             Member* member = program_interface->getMemberManager().searchMember(v.first);
             // map<unsigned long long, vector<Lecture*>> 에서 vector<Lecture*> 를 먼저 얻고
@@ -166,16 +166,14 @@ void EnrollManager::searchAndStudentEnrollLecture() {
         cout << "('-1' : 취소)" << endl;
         cin >> privateKey;
         if (privateKey == -1) { return; }
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
 
     lecture = program_interface->getLectureManager().searchLecture(privateKey);
     if (lecture == nullptr) {
         cout << "조회된 강의가 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         return;
     }
     else {
@@ -185,7 +183,7 @@ void EnrollManager::searchAndStudentEnrollLecture() {
 
         if (is_duplication == false) {
             cout << "수강 신청이 완료되었습니다." << endl;
-           unsigned long long studentKey = member->getPrimaryKey();
+            unsigned long long studentKey = member->getPrimaryKey();
 
             // 학생 키로 map 에서 vector 찾기
             auto it = this->studentLectureList.find(studentKey);
@@ -202,14 +200,12 @@ void EnrollManager::searchAndStudentEnrollLecture() {
                 this->studentLectureList.insert({ studentKey, {lecture} });
             }
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
         }
         else if (is_duplication == true) {
             cout << "이미 수강 신청한 강의입니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
         }
     }
 
@@ -246,14 +242,12 @@ void EnrollManager::instructorEnrollLecture() {
         Member* member = program_interface->getSessionManager().getLoginUser();
         this->instructorLectureList.insert({ member->getPrimaryKey() , {lecture} });
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
     else {
         cout << "강의가 정상적으로 생성되지 않았습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
     return;
 }

--- a/Koflearn/enrollManager.cpp
+++ b/Koflearn/enrollManager.cpp
@@ -179,7 +179,7 @@ void EnrollManager::searchAndStudentEnrollLecture() {
     else {
         bool is_duplication = false;
         Member* member = program_interface->getSessionManager().getLoginUser();
-        is_duplication = this->isDuplicationStudentEnrollLecture(member, lecture);
+        is_duplication = this->isDuplicationOrSizeCheckStudentEnrollLecture(member, lecture);
 
         if (is_duplication == false) {
             cout << "수강 신청이 완료되었습니다." << endl;
@@ -206,7 +206,6 @@ void EnrollManager::searchAndStudentEnrollLecture() {
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
         }
         else if (is_duplication == true) {
-            cout << "이미 수강 신청한 강의입니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
         }
@@ -215,7 +214,7 @@ void EnrollManager::searchAndStudentEnrollLecture() {
     return;
 }
 
-bool EnrollManager::isDuplicationStudentEnrollLecture(Member* member, Lecture* lecture) {
+bool EnrollManager::isDuplicationOrSizeCheckStudentEnrollLecture(Member* member, Lecture* lecture) {
     // 컨테이너 객체 '댕글링 포인터' 이슈 방지로 참조 값 변수 할당
     map<unsigned long long, vector<Lecture*>>& studentLectureList = program_interface->getEnrollManager().getStudentLectureList();
 
@@ -226,9 +225,16 @@ bool EnrollManager::isDuplicationStudentEnrollLecture(Member* member, Lecture* l
         // 2. 학생을 찾았다면 해당 학생의 강의 리스트(std::vector<Lecture*>)를 가져옴
         const vector<Lecture*>& lecturesOfStudent = it->second;
 
-        // 3. 이 리스트 내에서 현재 강의가 이미 있는지 순회로 체크
+        // 3. (학생이 수강하는 강의 갯수가 9개 초과인지 체크)
+        if (lecturesOfStudent.size() >= 9) {
+            cout << "최대 수강 신청한 강의는 9개 입니다." << endl;
+            return true; // 초과 시 더 이상 수강할 수 없음.
+        }
+
+        // 4. 이 리스트 내에서 현재 강의가 이미 있는지 순회로 체크
         for (const auto& i : lecturesOfStudent) {
             if (i && i->getPrimaryKey() == lecture->getPrimaryKey()) {
+                cout << "이미 수강 신청한 강의입니다." << endl;
                 return true; // 중복 발견
             }
         }

--- a/Koflearn/enrollManager.h
+++ b/Koflearn/enrollManager.h
@@ -33,12 +33,18 @@ public:
 	void searchAndStudentEnrollLecture();
 	void instructorEnrollLecture();
 	bool isDuplicationStudentEnrollLecture(Member* member, Lecture* lecture);
-	
+	// 학생이 수강하는 특정 한 강의 찾기
+	Lecture* findStudentLectureFromList(Lecture* lecture);
+	// 강사가 진행하는 특정 한 강의 찾기
+	Lecture* findInstructorLectureFromList(Lecture* lecture);
+	// 학생이 수강하는 모든 강의 찾기
+	vector<Lecture*>& findStudentLectureAllList(unsigned long long primaryKey);
+	// 강사가 진행하는 모든 강의 찾기
+	vector<Lecture*>& findInstructorLectureAllList(unsigned long long primaryKey);
+
 	string makeWelcomeText();
 
 	vector<string> parseCSV(istream&, char);
-
-
 
 	// 1.
 	// 컨테이너 객체의 경우 특정 변수에 값을 함수에서 반환을 통해 할당했을 때,

--- a/Koflearn/enrollManager.h
+++ b/Koflearn/enrollManager.h
@@ -32,7 +32,7 @@ public:
 
 	void searchAndStudentEnrollLecture();
 	void instructorEnrollLecture();
-	bool isDuplicationStudentEnrollLecture(Member* member, Lecture* lecture);
+	bool isDuplicationOrSizeCheckStudentEnrollLecture(Member* member, Lecture* lecture);
 	// 학생이 수강하는 특정 한 강의 찾기
 	Lecture* findStudentLectureFromList(Lecture* lecture);
 	// 강사가 진행하는 특정 한 강의 찾기

--- a/Koflearn/koflearnPlatManager.cpp
+++ b/Koflearn/koflearnPlatManager.cpp
@@ -38,6 +38,7 @@ SessionManager& KoflearnPlatManager::getSessionManager() {
 void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
     int ch;
     bool isContinue = true;
+    Lecture* lecture = nullptr;
 
     while (isContinue == true) {
         cout << "\033[2J\033[1;1H";
@@ -113,8 +114,10 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
             break;
         case 3:
             if (program->getSessionManager().getIs_login() == true) {
-                program->getLectureManager().inputLecture();
-                cout << "강의를 신규 등록하였습니다." << endl;
+                lecture = program->getLectureManager().inputLecture();
+                if (lecture != nullptr) {
+                    cout << "강의를 신규 등록하였습니다." << endl;
+                }
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
                 cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }

--- a/Koflearn/koflearnPlatManager.cpp
+++ b/Koflearn/koflearnPlatManager.cpp
@@ -69,7 +69,8 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
             // 스트림의 오류 상태를 초기화
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;
@@ -92,8 +93,7 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
 
                 cout << "정상적으로 로그아웃 되었습니다. " << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             else {
                 // 로그인 화면 이동
@@ -108,8 +108,7 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
             else {
                 cout << "로그인 후 강의 조회 및 신청이 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             break;
         case 3:
@@ -117,14 +116,12 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
                 program->getLectureManager().inputLecture();
                 cout << "강의를 신규 등록하였습니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             else {
                 cout << "로그인 후 강의 등록이 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             break;
         case 4:
@@ -134,8 +131,7 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
             else {
                 cout << "멤버(회원) 통합 관리 시스템은 관리자만 접근 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             break;
         case 5:
@@ -145,8 +141,7 @@ void KoflearnPlatManager::displayMenu(IKoflearnPlatManager* program) {
             else {
                 cout << "강의(제품) 통합 관리 시스템은 관리자만 접근 가능합니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             break;
         case 6:

--- a/Koflearn/koflearnPlatform.cpp
+++ b/Koflearn/koflearnPlatform.cpp
@@ -1,4 +1,4 @@
-#include "koflearnPlatform.h"
+﻿#include "koflearnPlatform.h"
 
 unsigned long long KoflearnPlatform::getPrimaryKey() const {
 	return this->primaryKey;

--- a/Koflearn/lecture.cpp
+++ b/Koflearn/lecture.cpp
@@ -55,7 +55,8 @@ void Lecture::setPrice(int price) {
 	this->price = price;
 }
 void Lecture::setEnrolledStudentsCount(int enrolledStudentCount) {
-	this->enrolledStudentsCount = enrolledStudentsCount;
+	// 두 값 중 큰 값으로 처리됨. 즉 외부에서 음수로 처리된 값이 와도 최소 0은 보장함.
+	this->enrolledStudentsCount = max(0, enrolledStudentCount);  // 음수 방지
 }
 void Lecture::setDurationHours(int durationHours) {
 	this->durationHours = durationHours;

--- a/Koflearn/lectureManager.cpp
+++ b/Koflearn/lectureManager.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 using namespace std;
 
 // 생성자에서 인터페이스 타입의 의존성을 주입받음
@@ -66,6 +67,10 @@ Lecture* LectureManager::inputLecture() {
     int price, enrolledStudentsCount, durationHours;
 
     unsigned long long primaryKey = makePrimaryKey();
+    if (primaryKey == -1) {
+        cout << "강의 최대 수용량이 초과하였습니다. (99,999,999,999)" << endl;
+        return nullptr;
+    }
 
     cout << "강의 명 : ";
     getline(cin, lectureTitle, '\n');
@@ -237,6 +242,9 @@ unsigned long long LectureManager::makePrimaryKey() {
     else {
         auto elem = lectureList.end();
         unsigned long long primaryKey = (--elem)->first;
+        if (primaryKey == 99999999999) {
+            return -1;
+        }
         return ++primaryKey;
     }
 }
@@ -278,6 +286,7 @@ void LectureManager::displayMenu()
     int ch;
     unsigned long long key;
     bool isContinue = true;
+    Lecture* lecture = nullptr;
 
     while (isContinue == true) {
         cout << "\033[2J\033[1;1H";
@@ -317,8 +326,10 @@ void LectureManager::displayMenu()
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 2:
-            inputLecture();
-            cout << "강의 등록이 완료되었습니다." << endl;
+            lecture = inputLecture();
+            if (lecture != nullptr) {
+                cout << "강의 등록이 완료되었습니다." << endl;
+            }
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;

--- a/Koflearn/lectureManager.cpp
+++ b/Koflearn/lectureManager.cpp
@@ -72,6 +72,19 @@ Lecture* LectureManager::inputLecture() {
         return nullptr;
     }
 
+    // 한 사람당 강의 개설은 최대 9개까지 개설 가능.
+    // 컨테이너 객체 반환받을 때 임시 객체 이슈로 댕글링 포인터될 수 있으므로 참조 값 받기
+    map<unsigned long long, vector<Lecture*>>& instructorLectureList = program_interface->getEnrollManager().getInstructorLectureList();
+    for (const auto& i : instructorLectureList) {
+        Lecture* lecture = nullptr;
+        if (i.first == program_interface->getSessionManager().getLoginUser()->getPrimaryKey()) {
+            if (i.second.size() > 9) {
+                cout << "한 사람당 강의 최대 개설은 9개까지만 가능합니다." << endl;
+                return nullptr;
+            }
+        }
+    }
+
     cout << "강의 명 : ";
     getline(cin, lectureTitle, '\n');
     cout << "강사 명 : ";
@@ -109,10 +122,7 @@ Lecture* LectureManager::inputLecture() {
     // 강의를 등록했을 때 "내 강의 보기" 리스트를 출력하기 위한 instructor(강의자) 기준 리스트에 데이터 추가
     Member* member = program_interface->getSessionManager().getLoginUser();
 
-    // 컨테이너 객체 반환받을 때 임시 객체 이슈로 댕글링 포인터될 수 있으므로 참조 값 받기
-    map<unsigned long long, vector<Lecture*>>& instructorLectureList = program_interface->getEnrollManager().getInstructorLectureList();
     // 특정 member privateKey 를 key 로 vector 에 여러 개 요소 삽입하기 !
-
     unsigned long long instructorKey = member->getPrimaryKey();
 
     // 강사 키로 map 에서 vector 찾기

--- a/Koflearn/lectureManager.cpp
+++ b/Koflearn/lectureManager.cpp
@@ -142,8 +142,7 @@ void LectureManager::displayAllLecture() const {
     if (lectureList.empty()) {
         cout << "등록된 강의가 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         return;
     }
 
@@ -176,8 +175,7 @@ void LectureManager::modifyLecture(unsigned long long primaryKey) {
         while (1) {
             cout << "수정할 항목을 선택하세요. \n(강의 명 : 1, 가격 : 2, 강의 시간 : 3, 난이도 : 4, [수정 종료] : 5) : ";
             cin >> op;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             switch (op)
             {
@@ -189,22 +187,19 @@ void LectureManager::modifyLecture(unsigned long long primaryKey) {
             case 2:
                 cout << "가격 수정 : ";
                 cin >> price;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
                 lecture->setPrice(price);
                 break;
             case 3:
                 cout << "강의 시간 수정 : ";
                 cin >> durationHours;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
                 lecture->setDurationHours(durationHours);
                 break;
             case 4:
                 cout << "난이도 수정(1 : 쉬움, 2: 보통, 3 : 어려움) : ";
                 cin >> integerLevel;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
                 if (integerLevel == 1) {
                     difficultyLevel = "쉬움";
@@ -305,7 +300,8 @@ void LectureManager::displayMenu()
             // 스트림의 오류 상태를 초기화
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;
@@ -318,39 +314,35 @@ void LectureManager::displayMenu()
         case 1: default:
             displayAllLecture();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 2:
             inputLecture();
             cout << "강의 등록이 완료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 3:
             displayAllLecture();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             deleteLecture(key);
             cout << "강의 삭제 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 4:
             displayAllLecture();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             modifyLecture(key);
             cout << "강의 수정 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 5:
             isContinue = false;

--- a/Koflearn/loginManager.cpp
+++ b/Koflearn/loginManager.cpp
@@ -48,7 +48,8 @@ void LoginManager::displayMenu()
             // 스트림의 오류 상태를 초기화
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;
@@ -64,8 +65,7 @@ void LoginManager::displayMenu()
             if (loginMember == nullptr) {
                 cout << "가입되지 않은 이메일입니다." << endl;
                 cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
             }
             else {
                 cout << "비밀번호 : ";
@@ -73,8 +73,7 @@ void LoginManager::displayMenu()
                 if (password != loginMember->getPassword()) {
                     cout << "패스워드를 다시 확인해주세요." << endl;
                     cout << "[Enter] 를 눌러 뒤로가기" << endl;
-                    while (getchar() != '\n');
-
+                    cin.ignore(numeric_limits<streamsize>::max(), '\n');
                 }
                 else {
                     cout << loginMember->getNickName() + " 님 환영합니다." << endl;
@@ -85,7 +84,7 @@ void LoginManager::displayMenu()
                         program_interface->getSessionManager().setIs_admin(true);
                     }
                     cout << "[Enter] 를 눌러 메인 페이지로 이동" << endl;
-                    while (getchar() != '\n');
+                    cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
                     isContinue = false;
                 }
@@ -102,15 +101,13 @@ void LoginManager::displayMenu()
                     program_interface->getSessionManager().setIs_admin(true);
                 }
                 cout << "[Enter] 를 눌러 메인 페이지로 자동 로그인됩니다." << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
                 isContinue = false;
             }
             else {
                 cout << "회원 가입이 취소되었습니다." << endl;
                 cout << "[Enter] 를 눌러 메인 페이지로 돌아가기" << endl;
-                while (getchar() != '\n');
-
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
                 isContinue = false;
             }
             break;

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 using namespace std;
 
 // 생성자에서 인터페이스 타입의 의존성을 주입받음
@@ -56,6 +57,12 @@ Member* MemberManager::inputMember()
     string nickname, email, password, phoneNumber;
     string rePassword;
 
+    unsigned long long primaryKey = this->makePrimaryKey();
+    if (primaryKey == -1) {
+        cout << "회원 최대 수용량을 초과하였습니다. (9,999,999,999)" << endl;
+        return nullptr;
+    }
+
     int isDuplicationNickName = 0;
     while (1) {
         cout << "닉네임 (2자 이상) : ";
@@ -94,9 +101,9 @@ Member* MemberManager::inputMember()
             cout << "이미 가입한 이메일입니다. 다시 입력해주세요." << endl;
             cout << "회원가입을 중단하시려면 'F' 키를 누르고 [Enter] 를 입력해주세요. " << endl;
         }
-        else if(isDuplicationEmail == 0) { break; }
+        else if (isDuplicationEmail == 0) { break; }
     }
-    
+
     int isSamePassword = 0;
     while (1) {
         cout << "패스워드 : ";
@@ -121,7 +128,7 @@ Member* MemberManager::inputMember()
             break;
         }
     }
-    
+
     int isDuplicationPhone = 0;
     while (1) {
         cout << "휴대폰 번호 : ";
@@ -156,11 +163,9 @@ Member* MemberManager::inputMember()
         }
         else if (managerPassKey.compare(getManagerKey()) == 0) {
             isManager = "true";
-            break; 
+            break;
         }
     }
-    
-    unsigned long long primaryKey = this->makePrimaryKey();
 
     Member* member = new Member(primaryKey, nickname, email,
                                 password, phoneNumber, isManager);
@@ -308,6 +313,9 @@ unsigned long long MemberManager::makePrimaryKey()
     else {
         auto elem = memberList.end();
         unsigned long long primaryKey = (--elem)->first;
+        if (primaryKey == 9999999999) {
+            return -1;
+        }
         return ++primaryKey;
     }
 }
@@ -362,6 +370,7 @@ void MemberManager::displayMenu()
     int ch;
     unsigned long long key;
     bool isContinue = true;
+    Member* member = nullptr;
 
     while (isContinue == true) {
         cout << "\033[2J\033[1;1H";
@@ -401,8 +410,10 @@ void MemberManager::displayMenu()
 
             break;
         case 2:
-            inputMember();
-            cout << "회원가입이 완료되었습니다." << endl;
+            member = inputMember();
+            if (member != nullptr) {
+                cout << "회원가입이 완료되었습니다." << endl;
+            }
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
 

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -228,8 +228,7 @@ void MemberManager::displayAllMembers() const {
     if (memberList.empty()) {
         cout << "등록된 멤버가 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         return;
     }
 
@@ -385,7 +384,8 @@ void MemberManager::displayMenu()
             // 스트림의 오류 상태를 초기화
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
+
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;
@@ -393,44 +393,41 @@ void MemberManager::displayMenu()
         // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
         cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
-
         switch (ch) {
         case 1: default:
             displayAllMembers();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             break;
         case 2:
             inputMember();
             cout << "회원가입이 완료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             break;
         case 3:
             displayAllMembers();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             deleteMember(key);
             cout << "멤버 삭제 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 4:
             displayAllMembers();
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
 
             modifyMember(key);
             cout << "멤버 수정 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
-
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             break;
         case 5:
             isContinue = false;

--- a/Koflearn/memberManager.cpp
+++ b/Koflearn/memberManager.cpp
@@ -1,5 +1,6 @@
 #include "member.h"
 #include "memberManager.h"
+#include "myPageManager.h"
 
 #include <vector>
 #include <algorithm>
@@ -65,7 +66,7 @@ Member* MemberManager::inputMember()
 
     int isDuplicationNickName = 0;
     while (1) {
-        cout << "닉네임 (2자 이상) : ";
+        cout << "이름 (2자 이상) : ";
         getline(cin, nickname, '\n');
         if (nickname.compare("F") == 0) {
             cout << "'F' 키를 입력했으므로 회원가입을 중단합니다." << endl;
@@ -73,14 +74,14 @@ Member* MemberManager::inputMember()
         }
 
         else if (nickname.length() < 2) {
-            cout << "닉네임의 길이는 2자리 이상이어야 합니다." << endl;
+            cout << "이름의 길이는 2자리 이상이어야 합니다." << endl;
             cout << "회원가입을 중단하시려면 'F' 키를 누르고 [Enter] 를 입력해주세요. " << endl;
             continue;
         }
 
         isDuplicationNickName = this->nickNameDuplicationCheck(nickname);
         if (isDuplicationNickName == 1) {
-            cout << "중복된 닉네임입니다. 다시 입력해주세요." << endl;
+            cout << "중복된 이름입니다. 다시 입력해주세요." << endl;
             cout << "회원가입을 중단하시려면 'F' 키를 누르고 [Enter] 를 입력해주세요. " << endl;
             continue;
         }
@@ -237,7 +238,7 @@ void MemberManager::displayAllMembers() const {
         return;
     }
 
-    cout << "    key      |            Email(ID)          |   nickName   |    Phone Number    |   isManager   |" << endl;
+    cout << "    key      |            Email(ID)          |     Name     |    Phone Number    |   isManager   |" << endl;
     for (const auto& member : memberList) {
         member.second->displayInfo(); // 단순 멤버 객체(Member) read 책임은 Member 클래스가 맡음
     }
@@ -254,7 +255,7 @@ void MemberManager::modifyMember(unsigned long long primaryKey)
 {
     Member* member = searchMember(primaryKey);
     if (member != nullptr) {
-        cout << "    key     |            Email(ID)          |   nickName   |    Phone Number    |   isManager   |" << endl;
+        cout << "    key     |            Email(ID)          |     Name     |    Phone Number    |   isManager   |" << endl;
         cout << setw(11) << setfill('0') << right << member->getPrimaryKey() << " | " << left;
         cout << setw(29) << setfill(' ') << member->getEmail() << " | ";
         cout << setw(12) << setfill(' ') << member->getNickName() << " | ";
@@ -423,7 +424,7 @@ void MemberManager::displayMenu()
             cout << "   멤버 primaryKey 입력 : ";
             cin >> key;
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
-
+            program_interface->getMyPageManager().allDeletedUserData(key);
             deleteMember(key);
             cout << "멤버 삭제 작업이 종료되었습니다." << endl;
             cout << "[Enter] 를 눌러 뒤로가기" << endl;

--- a/Koflearn/myPageManager.cpp
+++ b/Koflearn/myPageManager.cpp
@@ -106,55 +106,23 @@ void MyPageManager::allDeletedUserData(unsigned long long primaryKey) {
     auto& instructorLectureList = program_interface->getEnrollManager().getInstructorLectureList();
     auto& studentLectureList = program_interface->getEnrollManager().getStudentLectureList();
 
-    // 1. 해당 강사가 개설한 강의 리스트 수집
+    // 1. 해당 강사가 개설한 강의 리스트 수집 -> lectureList 제거
     vector<Lecture*> lecturesToDelete;
     for (auto it = lectureList.begin(); it != lectureList.end(); ) {
         Lecture* lec = it->second;
         if (lec && lec->getInstructorName() == name) {
             lecturesToDelete.push_back(lec);
-            // it = lectureList.erase(it);
-        }
-        ++it;
-    }
-
-    // 2. instructorLectureList 에서 해당 강사 항목 제거
-    instructorLectureList.erase(instructorPrimaryKey);
-
-    // 3. studentLectureList 에서 강사 강의 제거 + 수강자 수 감소
-    for (auto it = studentLectureList.begin(); it != studentLectureList.end(); ) {
-        vector<Lecture*>& lectures = it->second;
-
-        // 수강자 수 감소 및 삭제할 강의 필터링
-        auto new_end = remove_if(lectures.begin(), lectures.end(),
-            [&](Lecture* l) {
-                for (Lecture* del : lecturesToDelete) {
-                    if (l == del) {
-                        int count = l->getEnrolledStudentsCount();
-                        l->setEnrolledStudentsCount(count - 1);
-                        return true;
-                    }
-                }
-                return false;
-            });
-
-        lectures.erase(new_end, lectures.end());
-
-        // 수강 리스트 비었으면 map에서도 제거
-        if (lectures.empty()) {
-            it = studentLectureList.erase(it);
+            it = lectureList.erase(it);
         }
         else {
             ++it;
         }
     }
 
-    for (Lecture* lecture : lecturesToDelete) {
-        if (lecture) {
-            lectureList.erase(lecture->getPrimaryKey());  // 실제 삭제는 여기서 수행
-        }
-    }
+    // 2. instructorLectureList 에서 해당 강사 항목 제거
+    instructorLectureList.erase(instructorPrimaryKey);
 
-    // 4. 회원이 수강자(Student)인 경우 -> 본인의 수강 리스트에서 수강자 수 감소 + 제거
+    // 3. 회원이 수강자(Student)인 경우 -> 본인의 수강 리스트(studentLectureList)에서 수강자 수 감소 + 제거
     auto it = studentLectureList.find(primaryKey);
     if (it != studentLectureList.end()) {
         vector<Lecture*>& lectures = it->second;

--- a/Koflearn/myPageManager.cpp
+++ b/Koflearn/myPageManager.cpp
@@ -37,9 +37,76 @@ void MyPageManager::myStudentLecturePrint() {
             i->displayInfo();
         }
         cout << endl;
+        int ch;
+        while (1) {
+            cout << "1. 뒤로 가기" << endl;
+            cout << "2. 수강 종료하기" << endl;
+            cin >> ch;
+            if (cin.fail()) {
+                cout << "잘못된 입력입니다. 숫자를 입력해주세요." << endl;
+                // 스트림의 오류 상태를 초기화
+                cin.clear();
+                cout << "[Enter] 를 눌러 다시 입력하기" << endl;
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
+                continue;
+            }
+            if (ch == 1) {
+                cout << "[Enter] 를 눌러 뒤로가기" << endl;
+                cin.ignore(numeric_limits<streamsize>::max(), '\n');
+                break;
+            }
+            else if (ch == 2) {
+                unsigned long long primaryKey;
+                cout << "수강 종료할 강좌의 key 를 입력하세요 : ";
+                cin >> primaryKey;
+                exitLecture(primaryKey);
+                break;
+            }
+            else {
+                continue;
+            }
+        }
+    }
+}
+
+void MyPageManager::exitLecture(unsigned long long primaryKey) {
+    Lecture* lecture = program_interface->getLectureManager().searchLecture(primaryKey);
+    unsigned long long myPrimaryKey = program_interface->getSessionManager().getLoginUser()->getPrimaryKey();
+    auto& studentLectureList = program_interface->getEnrollManager().getStudentLectureList();
+
+    // 회원의 수강 리스트(studentLectureList)에서 수강자 수 감소
+    auto it = studentLectureList.find(myPrimaryKey);
+    if (lecture && it != studentLectureList.end()) {
+        vector<Lecture*>& lectures = it->second;
+        // 벡터에서 해당 강의를 찾아 수강자 수 감소 및 제거
+        for (auto vecIt = lectures.begin(); vecIt != lectures.end(); ++vecIt) {
+            if (*vecIt && (*vecIt)->getPrimaryKey() == primaryKey) {
+                int count = (*vecIt)->getEnrolledStudentsCount();
+                (*vecIt)->setEnrolledStudentsCount(count - 1);  // 수강자 수 감소
+
+                lectures.erase(vecIt);  // 강의 벡터에서 제거
+                break;  // 하나만 삭제하고 종료(어차피 회원이 중복 강의를 수강할 수 는 없음)
+            }
+        }
+
+        // 해당 학생의 수강 목록이 비었으면 map에서도 삭제
+        if (lectures.empty()) {
+            studentLectureList.erase(it);
+        }
+
+        cout << lecture->getLectureTitle() << " 강의를 수강 종료처리하였습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
         cin.ignore(numeric_limits<streamsize>::max(), '\n');
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
+    else {
+        cout << "[Enter] 를 눌러 뒤로가기" << endl;
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
+    }
+
+    return;
 }
 
 void MyPageManager::myInstructorLecturePrint() {
@@ -151,7 +218,7 @@ void MyPageManager::displayMenu() {
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << "               Koflearn My Page                  " << endl;
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
-        cout << "  1. 수강 중인 강의 보기                     " << endl;
+        cout << "  1. 수강 중인 강의 및 수강 종료                     " << endl;
         cout << "  2. 진행하는 강의 보기                            " << endl;
         cout << "  3. 패스워드 수정                            " << endl;
         cout << "  4. 회원 탈퇴                       " << endl;
@@ -159,7 +226,6 @@ void MyPageManager::displayMenu() {
         cout << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
         cout << " 기능을 선택하세요 : ";
         cin >> ch;
-        
         // 메뉴에서 숫자 명령어를 받으려고 할 때 영문자 등을 입력했을 때 
         // 무한 깜빡임 현상 해결
         if (cin.fail()) {
@@ -168,10 +234,12 @@ void MyPageManager::displayMenu() {
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
+
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;
         }
+        
         // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
         cin.ignore(numeric_limits<streamsize>::max(), '\n');
 

--- a/Koflearn/myPageManager.cpp
+++ b/Koflearn/myPageManager.cpp
@@ -39,14 +39,12 @@ void MyPageManager::myStudentLecturePrint() {
         cout << endl;
         cout << "현재 수강 중인 강좌가 없습니다 !" << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
     else {
         cout << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
 }
 
@@ -69,14 +67,12 @@ void MyPageManager::myInstructorLecturePrint() {
         cout << endl;
         cout << "현재 진행하시는 강좌가 없습니다 !" << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
     else {
         cout << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
 }
 
@@ -97,15 +93,13 @@ bool MyPageManager::selfDeleteID() {
         
         cout << "회원 탈퇴가 정상적으로 되었습니다." << endl;
         cout << "로그인 상태가 해제되고 [Enter] 를 누르면 메인 페이지로 이동합니다." << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         return true;
     }
     else {
         cout << "문구를 정상적으로 입력하지 않아 회원 탈퇴를 진행할 수 없습니다." << endl;
         cout << "[Enter] 를 눌러 뒤로가기" << endl;
-        while (getchar() != '\n');
-
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
         return false;
     }
 }
@@ -204,7 +198,7 @@ void MyPageManager::displayMenu() {
             // 스트림의 오류 상태를 초기화
             cin.clear();
             cout << "[Enter] 를 눌러 뒤로가기" << endl;
-            while (getchar() != '\n');
+            cin.ignore(numeric_limits<streamsize>::max(), '\n');
             // 버퍼의 최대 크기, '\n'은 버퍼를 비울 때까지 찾을 문자
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
             continue;

--- a/Koflearn/myPageManager.h
+++ b/Koflearn/myPageManager.h
@@ -19,6 +19,7 @@ public:
 	void myInstructorLecturePrint();
 	bool selfDeleteID();
 	void allDeletedUserData(unsigned long long primaryKey);
+	void exitLecture(unsigned long long primaryKey);
 };
 
 #endif // !_MYPAGE_MANAGER_H_

--- a/Koflearn/myPageManager.h
+++ b/Koflearn/myPageManager.h
@@ -18,7 +18,7 @@ public:
 	void myStudentLecturePrint();
 	void myInstructorLecturePrint();
 	bool selfDeleteID();
-	void allDeletedUserData();
+	void allDeletedUserData(unsigned long long primaryKey);
 };
 
 #endif // !_MYPAGE_MANAGER_H_


### PR DESCRIPTION
**Feat**
1. commit log - ae219d9 : PrimaryKey 에 따른 회원 또는 강의 생성 제한 기능 추가
-> 회원 : 1 ~ 9,999,999,999
강의 : 10,000,000,001 ~ 99,999,999,999 생성 가능 갯수 제한
2. commit log - 1cf3d03 : 한 회원당 강의 최대 개설 9개까지 제한 기능 추가
3. commit log - 0adffcb : lecture 의 student_count(강의 신청자 수) 기능, 회원 삭제 기능 추가
-> 3-1. 사용자가 강의를 신청할 때 해당 강의(lecture) 의 enrolledStudentCount(신청자 수) 증가
-> 3-2. 사용자가 회원 탈퇴할 때, 신청했던 강의의 enrolledStudentCount(강의 신청자 수) 감소
-> 3-3. 사용자가 회원 탈퇴할 때, 사용자의 강의(lecture) 삭제 / 사용자가 진행하던 강의(instructorLectureList) 모두 삭제 / 사용자가 수강하던 강의 리스트에서 수강자 수 감소 및 데이터 제거(studentLectureList)
4. commit log - b2f1ded : 마이페이지에서 본인이 수강하고 있는 강의를 수강 종료할 수 있는 기능 추가
-> studentLectureList 에서 enrolledStudentCount 수 감소 처리

**Fix**
1. commit log - 0adffcb : enrollManager 클래스 생성자에서 data 를 read 할 때, Member 와 Lecture 를 new 로 생성하지 않고, 기존의 member, lecture 의 주소 값을 가져올 수 있도록 수정함.
2. commit log - dbfd24b : 회원 삭제 시 연관 데이터 처리 함수 수정

**Refactor**
1. commit log - 56ec3c5 : 개행 문자 버퍼 제거 기법 변경(c style -> c++ style)
-> 기존 while(getchar()!='\n'); -> 변경
cin.ignore(numeric_limits<streamsize>::max(), '\n'); 으로 변경함. 입력 버퍼에서 문자를 최대로 읽되 개행문자를 만나면 멈춘다. (C++
스타일로 더 직관적임)